### PR TITLE
Script: delay by 1 second before hitting add button

### DIFF
--- a/runmeDUTCH.applescript
+++ b/runmeDUTCH.applescript
@@ -39,6 +39,8 @@ repeat with i from 1 to length of recs
 			tell window 1
 				
 				click button "Voeg toe" of group 1 of group 1 of it
+				delay 1
+
 				-- write fields
 				tell sheet 1 of it
 					set value of text field 1 of it to kcURL

--- a/runmeENGLISH.applescript
+++ b/runmeENGLISH.applescript
@@ -39,6 +39,8 @@ repeat with i from 1 to length of recs
 			tell window 1
 				
 				click button "Add" of group 1 of group 1 of it
+				delay 1
+
 				-- write fields
 				tell sheet 1 of it
 					set value of text field 1 of it to kcURL


### PR DESCRIPTION
* On the latest Safari version there seems to be a bug which causes Safari to crash when clicking the add button too fast. Fix it by adding a 1 second delay between every click